### PR TITLE
Fixes for 201911 lensed cmb simulation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -73,7 +73,7 @@ an example we will use all defaults options::
 
     NSIDE = 16
     cmb = mapsims.SOPrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=NSIDE,
         lensed=False,
         aberrated=False,

--- a/mapsims/cmb.py
+++ b/mapsims/cmb.py
@@ -65,9 +65,7 @@ class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
             returns (nfreqs,ncomp,Ny,Nx) rectangular pixel ndmap.
         """
 
-        filename = _get_cmb_map_string(
-            cmb_dir, num, cmb_set, lensed, aberrated
-        )
+        filename = _get_cmb_map_string(cmb_dir, num, cmb_set, lensed, aberrated)
 
         super().__init__(
             filename,
@@ -105,9 +103,7 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
         can be obtained by calling `get_phi_alm()`.
         """
 
-        filename = _get_cmb_map_string(
-            cmb_dir, num, cmb_set, lensed, aberrated
-        )
+        filename = _get_cmb_map_string(cmb_dir, num, cmb_set, lensed, aberrated)
 
         self.iteration_num = num
         self.cmb_dir = cmb_dir
@@ -138,9 +134,7 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
             Units as defined by `pysm.convert_units`, e.g. uK_CMB or K_RJ
         """
         return self.get_emission(
-            nu=ch.center_frequency,
-            fwhm=ch.beam,
-            output_units=output_units,
+            freqs=ch.center_frequency, fwhm=ch.beam, output_units=output_units
         )
 
 

--- a/mapsims/cmb.py
+++ b/mapsims/cmb.py
@@ -7,7 +7,7 @@ import pysm.units as u
 class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
     def __init__(
         self,
-        iteration_num,
+        num,
         nside=None,  # set this if healpix is desired
         shape=None,  # set shape and wcs if CAR maps are desired
         wcs=None,
@@ -30,7 +30,7 @@ class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
 
         Parameters
         ----------
-        iteration_num : int
+        num : int
             integer specifying which sim iteration to use
         input_units : string
             Input unit strings as defined by pysm.convert_units, e.g. K_CMB, uK_RJ, MJysr
@@ -66,7 +66,7 @@ class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
         """
 
         filename = _get_cmb_map_string(
-            cmb_dir, iteration_num, cmb_set, lensed, aberrated
+            cmb_dir, num, cmb_set, lensed, aberrated
         )
 
         super().__init__(
@@ -83,7 +83,7 @@ class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
 class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
     def __init__(
         self,
-        iteration_num,
+        num,
         nside=None,  # set this if healpix is desired
         shape=None,  # set shape and wcs if CAR maps are desired
         wcs=None,
@@ -106,10 +106,10 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
         """
 
         filename = _get_cmb_map_string(
-            cmb_dir, iteration_num, cmb_set, lensed, aberrated
+            cmb_dir, num, cmb_set, lensed, aberrated
         )
 
-        self.iteration_num = iteration_num
+        self.iteration_num = num
         self.cmb_dir = cmb_dir
 
         super().__init__(
@@ -138,8 +138,8 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
             Units as defined by `pysm.convert_units`, e.g. uK_CMB or K_RJ
         """
         return self.get_emission(
-            nu=ch.band << u.GHz,
-            fwhm=so_utils.get_beam(ch.telescope, ch.band) * u.arcmin,
+            nu=ch.center_frequency,
+            fwhm=ch.beam,
             output_units=output_units,
         )
 

--- a/mapsims/data/example_config.toml
+++ b/mapsims/data/example_config.toml
@@ -39,7 +39,7 @@ num = 0
 
     [ pysm_components.cmb ]
     class  =  "mapsims.SOPrecomputedCMB"
-    iteration_num = 0
+    num = 0
     lensed = false
     # At NERSC use:
     # lensed = true

--- a/mapsims/runner.py
+++ b/mapsims/runner.py
@@ -61,6 +61,7 @@ def from_config(config_file, override=None):
         config.update(override)
 
     pysm_components_string = None
+    pysm_output_reference_frame = None
 
     components = {}
     for component_type in ["pysm_components", "other_components"]:

--- a/mapsims/runner.py
+++ b/mapsims/runner.py
@@ -77,6 +77,11 @@ def from_config(config_file, override=None):
             for comp_name in component_type_config:
                 comp_config = component_type_config[comp_name]
                 comp_class = import_class_from_string(comp_config.pop("class"))
+                if "num" in comp_config and "num" in config:
+# If a component has an argument "num" and we provide a configuration
+# "num" to MapSims, we override it.
+# This is used for example by `SOStandalonePrecomputedCMB`
+                    comp_config["num"] = config["num"]
                 components[component_type][comp_name] = comp_class(
                     nside=config["nside"], **comp_config
                 )

--- a/mapsims/runner.py
+++ b/mapsims/runner.py
@@ -79,9 +79,9 @@ def from_config(config_file, override=None):
                 comp_config = component_type_config[comp_name]
                 comp_class = import_class_from_string(comp_config.pop("class"))
                 if "num" in comp_config and "num" in config:
-# If a component has an argument "num" and we provide a configuration
-# "num" to MapSims, we override it.
-# This is used for example by `SOStandalonePrecomputedCMB`
+                    # If a component has an argument "num" and we provide a configuration
+                    # "num" to MapSims, we override it.
+                    # This is used for example by `SOStandalonePrecomputedCMB`
                     comp_config["num"] = config["num"]
                 components[component_type][comp_name] = comp_class(
                     nside=config["nside"], **comp_config

--- a/mapsims/tests/test_cmb.py
+++ b/mapsims/tests/test_cmb.py
@@ -19,25 +19,27 @@ def test_load_sim():
     nside = 32
     # Make an IQU sim
     imap = cmb.SOPrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=nside,
         cmb_dir=cmb_dir,
         lensed=False,
         aberrated=False,
         input_reference_frequency=148 * u.GHz,
+        input_units="uK_RJ",
     ).get_emission(148 * u.GHz)
     imap_test = hp.read_map(save_name, field=(0, 1, 2)) << u.uK_RJ
     assert_quantity_allclose(imap, imap_test)
     assert imap.shape[0] == 3
     # Make an I only sim
     imap = cmb.SOPrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=nside,
         has_polarization=False,
         cmb_dir=cmb_dir,
         lensed=False,
         aberrated=False,
         input_reference_frequency=148 * u.GHz,
+        input_units="uK_RJ",
     ).get_emission(148 * u.GHz)
 
 
@@ -49,7 +51,7 @@ def test_standalone_cmb():
     ch = so_utils.SOChannel("SA", 145)
     # Make an IQU sim
     imap = cmb.SOStandalonePrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=nside,
         cmb_dir=cmb_dir,
         lensed=False,

--- a/mapsims/tests/test_runner.py
+++ b/mapsims/tests/test_runner.py
@@ -42,7 +42,7 @@ def test_from_classes():
     )
 
     cmb = mapsims.SOPrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=NSIDE,
         lensed=False,
         aberrated=False,

--- a/mapsims/tests/test_runner_custominstrument.py
+++ b/mapsims/tests/test_runner_custominstrument.py
@@ -16,7 +16,7 @@ NSIDE = 16
 def test_from_classes_custominstrument():
 
     cmb = mapsims.SOPrecomputedCMB(
-        iteration_num=0,
+        num=0,
         nside=NSIDE,
         lensed=False,
         aberrated=False,


### PR DESCRIPTION
Mostly passing the `num` parameter (used to set the CMB realization) into any component that requests it.