### PR TITLE
More noise simulation features (#45)

### DIFF
--- a/bin/test_noise_v2.py
+++ b/bin/test_noise_v2.py
@@ -77,7 +77,7 @@ for key in config.keys():
         homogenous=c.homogenous,
         sky_fraction=c.fsky if c.homogenous else None,
     )
-    ells, nlt, nlp = nsim.get_noise_spectra(c.tube, ncurve_fsky=c.fsky)
+    ells, nlt, nlp = nsim.get_noise_spectra(c.tube, ncurve_sky_fraction=c.fsky)
 
     if not(c.homogenous):
         try:

--- a/mapsims/tests/data/generate_noise_car_data.py
+++ b/mapsims/tests/data/generate_noise_car_data.py
@@ -1,0 +1,37 @@
+import numpy as np
+import healpy as hp
+
+import pytest
+from astropy.tests.helper import assert_quantity_allclose
+
+from astropy.utils import data
+import mapsims
+import pysm.units as u
+from mapsims import so_utils
+from pixell import enmap
+from orphics import io
+
+res = np.deg2rad(30 / 60.) 
+
+seed = 1234
+shape,wcs = enmap.fullsky_geometry(res=res)
+simulator = mapsims.SONoiseSimulator(shape=shape,wcs=wcs)
+for tube in ["LT0", "ST3"]:
+    output_map = simulator.simulate(tube,seed=seed)
+    fname = f"noise_{tube}_uKCMB_classical_res30_seed1234_car"
+    expected_map = enmap.write_map(
+        f"{fname}.fits",
+        output_map
+    )
+
+
+nside = 16
+simulator = mapsims.SONoiseSimulator(nside=nside)
+for tube in ["ST0", "ST3"]:
+    output_map = simulator.simulate(tube,seed=seed)
+    for i,band in enumerate(so_utils.tubes[tube]):
+        fname = f"noise_{tube}_{band}_uKCMB_classical_nside16_seed1234_healpix"
+        expected_map = hp.write_map(
+            f"{fname}.fits",
+            output_map[i,0]
+        )

--- a/mapsims/tests/test_load_hitmaps.ipynb
+++ b/mapsims/tests/test_load_hitmaps.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.testing.assert_allclose(sky_fractions, [0.3871561686197917, 0.3871561686197917])"
+    "np.testing.assert_allclose(sky_fractions, [0.087107, 0.087107],rtol=1e-5)"
    ]
   }
  ],

--- a/mapsims/tests/test_noise.py
+++ b/mapsims/tests/test_noise.py
@@ -34,6 +34,7 @@ def test_noise_simulator(tube):
                 f"data/noise_{tube}_{band}_uKCMB_classical_nside16_seed1234_healpix.fits.gz"
             ),
             (0, 1, 2),
+            verbose=False,
         )
         assert_quantity_allclose(output_map[i, 0], expected_map)
 
@@ -54,4 +55,4 @@ def test_noise_simulator_car(tube):
             f"data/noise_{tube}_uKCMB_classical_res30_seed1234_car.fits.gz"
         )
     )
-    assert_quantity_allclose(output_map, expected_map)
+    assert_quantity_allclose(output_map, expected_map, rtol=1e-5)

--- a/mapsims/utils/__init__.py
+++ b/mapsims/utils/__init__.py
@@ -7,7 +7,6 @@ import os
 from astropy.utils import data
 import warnings
 
-
 def _DATAURL(healpix, version):
     if healpix:
         return f"https://portal.nersc.gov/project/sobs/so_mapsims_data/{version}/healpix/"


### PR DESCRIPTION
* white noise re-scaling and correlation coefficient based rescaling (this only results in a change where the geometric means of the two sky fractions are used instead of the arithmetic mean, but the difference is so small it doesnt break tests)

* comments and black formatting

* progress towards ivar

* change fsky definition to <Nhits>, instead of later re-scaling to that definition. This makes no difference to the healpix maps but breaks the CAR test because the previous re-scaling for CAR was incorrect.

* completed ivar function

* test update

* suppress warnings in SO noise model ; increase tolerance of tests on high resolution CAR

* ivar units

* black formatting and test generation script

* tests pass

* update sky_fraction test

* apply homogenous fix from previous PR

* change fsky to sky_fraction

* docstring update fixes #51

* move some functions outside class ; docstring improvements

* revert to function back inside class

Co-authored-by: Andrea Zonca <code@andreazonca.com>