### PR TITLE
Misc. fixes

### DIFF
--- a/mapsims/noise.py
+++ b/mapsims/noise.py
@@ -142,6 +142,7 @@ class SONoiseSimulator:
                 ell_max if ell_max is not None else 10000 * (1.0 / self._pixheight)
             )
             self.pixarea_map = pixell.enmap.pixsizemap(self.shape, self.wcs)
+            self.map_area = pixell.enmap.area(self.shape,self.wcs)
         else:
             assert shape is None
             assert wcs is None
@@ -149,6 +150,7 @@ class SONoiseSimulator:
             self.nside = nside
             self.ell_max = ell_max if ell_max is not None else 3 * nside
             self.pixarea_map = hp.nside2pixarea(nside)
+            self.map_area = 4. * np.pi
 
         self.rolloff_ell = rolloff_ell
         self.boolean_sky_fraction = boolean_sky_fraction
@@ -411,7 +413,7 @@ class SONoiseSimulator:
             assert imap.ndim == 1
         else:
             assert imap.ndim == 2
-        return (self.pixarea_map * imap).sum() / 4.0 / np.pi
+        return (self.pixarea_map * imap).sum() / (self.map_area)
 
     def _process_hitmaps(self, hitmaps):
         """Internal function to process hitmaps and based on the
@@ -470,7 +472,7 @@ class SONoiseSimulator:
             car_suffix = ""
 
         bands = [ch.band for ch in self.tubes[tube]]
-
+        
         rnames = []
         for band in bands:
             rnames.append(
@@ -550,21 +552,23 @@ class SONoiseSimulator:
         """
         fsky, hitmaps = self._get_requested_hitmaps(tube, hitmap)
         wnoise_scale = self._get_wscale_factor(white_noise_rms, tube, fsky)
+        sel = np.s_[:,None] if self.healpix else np.s_[:,None,None]
         power = (
-            self.get_white_noise_power(tube, sky_fraction=1, units="arcmin2")
-            * fsky
-            * wnoise_scale
+            self.get_white_noise_power(tube, sky_fraction=1, units="sr")[sel]
+            * fsky[sel]
+            * wnoise_scale[:,0][sel]
         )
         """
         We now have the physical white noise power uK^2-sr
         and the hitmap
         ivar = hitmap * pixel_area * fsky / <hitmap> / power
         """
+        avgNhits = np.asarray([self._average(hitmaps[i]) for i in range(2)])
         ret = (
             hitmaps
-            * self.pmap
-            * fsky
-            / np.asarray([self._average(hitmaps[i]) for i in range(2)])
+            * self.pixarea_map
+            * fsky[sel]
+            / avgNhits[sel]
             / power
         )
         # Convert to desired units
@@ -586,7 +590,7 @@ class SONoiseSimulator:
             self.get_white_noise_power(tube, sky_fraction=1, units="arcmin2")
             * sky_fraction
         )
-        return white_noise_rms / cnoise
+        return (white_noise_rms / cnoise)[:,None]
 
     def _get_requested_hitmaps(self, tube, hitmap):
         if self.homogeneous and (hitmap is None):
@@ -595,9 +599,9 @@ class SONoiseSimulator:
                 if self.healpix
                 else pixell.enmap.ones(self.shape, self.wcs)
             )
-            hitmaps = [ones, ones] if self.full_covariance else ones.reshape((1, -1))
+            hitmaps = np.asarray([ones, ones]) if self.full_covariance else ones.reshape((1, -1))
             fsky = self._sky_fraction if self._sky_fraction is not None else 1
-            sky_fractions = [fsky, fsky] if self.full_covariance else [fsky]
+            sky_fractions = np.asarray([fsky, fsky]) if self.full_covariance else np.asarray([fsky])
         else:
             hitmaps, sky_fractions = self.get_hitmaps(tube, hitmap=hitmap)
 
@@ -612,7 +616,7 @@ class SONoiseSimulator:
             raise ValueError
         return fsky, hitmaps
 
-    def get_noise_properties(self, tube, nsplits=1, hitmap=None, white_noise_rms=None):
+    def get_noise_properties(self, tube, nsplits=1, hitmap=None, white_noise_rms=None,atmosphere=True):
         """Get noise curves scaled with the hitmaps and the hitmaps themselves
 
         Parameters
@@ -627,21 +631,33 @@ class SONoiseSimulator:
             Tube noise spectra for T and P, one row per channel, the 3rd the crosscorrelation
         fsky : np.array
             Array of sky fractions computed as <normalized N_hits>
-        wnoise_scale : np.array
-            White noise scaling, 1 if no input white_noise_rms is provided
+        wnoise_power : np.array
+            White noise power (high-ell limit)
         hitmaps : np.array
             Array of the hitmaps for each channel
         """
         fsky, hitmaps = self._get_requested_hitmaps(tube, hitmap)
         wnoise_scale = self._get_wscale_factor(white_noise_rms, tube, fsky)
-        ell, ps_T, ps_P = self.get_fullsky_noise_spectra(
-            tube, ncurve_sky_fraction=1, return_corr=True
+        wnoise_power = (
+            self.get_white_noise_power(tube, sky_fraction=1, units="sr")
+            * nsplits
+            * fsky
+            * wnoise_scale.flatten()
         )
-        ps_T[:2] = ps_T[:2] * fsky[:, None] * nsplits * wnoise_scale
-        ps_T[2] *= np.sqrt(np.prod(ps_T[:2], axis=0))
-        ps_P[:2] = ps_P[:2] * fsky[:, None] * nsplits * wnoise_scale
-        ps_P[2] *= np.sqrt(np.prod(ps_P[:2], axis=0))
-        return ell, ps_T, ps_P, fsky, wnoise_scale, hitmaps
+        if atmosphere:
+            ell, ps_T, ps_P = self.get_fullsky_noise_spectra(
+                tube, ncurve_sky_fraction=1, return_corr=True
+            )
+            ps_T[:2] = ps_T[:2] * fsky[:, None] * nsplits * wnoise_scale
+            ps_T[2] *= np.sqrt(np.prod(ps_T[:2], axis=0))
+            ps_P[:2] = ps_P[:2] * fsky[:, None] * nsplits * wnoise_scale
+            ps_P[2] *= np.sqrt(np.prod(ps_P[:2], axis=0))
+        else:
+            ell = np.arange(self.ell_max)
+            ps_T = np.zeros((3,ell.size))
+            ps_T[:2] = wnoise_power[:,None] * np.ones((2,ell.size))
+            ps_P = 2. * ps_T
+        return ell, ps_T, ps_P, fsky, wnoise_power, hitmaps
 
     def simulate(
         self,
@@ -727,7 +743,7 @@ class SONoiseSimulator:
 
         # In the third row we return the correlation coefficient P12/sqrt(P11*P22)
         # since that can be used straightforwardly when the auto-correlations are re-scaled.
-        ell, ps_T, ps_P, fsky, wnoise_scale, hitmaps = self.get_noise_properties(tube, nsplits=nsplits, hitmap=hitmap, white_noise_rms=white_noise_rms)
+        ell, ps_T, ps_P, fsky, wnoise_power, hitmaps = self.get_noise_properties(tube, nsplits=nsplits, hitmap=hitmap, white_noise_rms=white_noise_rms, atmosphere=atmosphere)
 
         if not (atmosphere):
             if self.apply_beam_correction:
@@ -736,23 +752,17 @@ class SONoiseSimulator:
                 )
             # If no atmosphere is requested, we use a simpler/faster method
             # that generates white noise in real-space.
-            npower = (
-                self.get_white_noise_power(tube, sky_fraction=1, units="arcmin2")
-                * nsplits
-                * fsky
-                * wnoise_scale.flatten()
-            )
             if self.healpix:
                 ashape = (hp.nside2npix(self.nside),)
                 sel = np.s_[:, None, None, None]
-                pmap = self.pixarea_map * ((180.0 * 60.0 / np.pi) ** 2.0)
+                pmap = self.pixarea_map 
             else:
                 ashape = self.shape[-2:]
                 sel = np.s_[:, None, None, None, None]
-                pmap = pixell.enmap.pixell.enmap(
-                    self.pixarea_map * ((180.0 * 60.0 / np.pi) ** 2.0), self.wcs
+                pmap = pixell.enmap.enmap(
+                    self.pixarea_map , self.wcs
                 )
-            spowr = np.sqrt(npower[sel] / pmap)
+            spowr = np.sqrt(wnoise_power[sel] / pmap)
             output_map = spowr * np.random.standard_normal((2, nsplits, 3) + ashape)
             output_map[:, :, 1:, :] = output_map[:, :, 1:, :] * np.sqrt(2.0)
         else:

--- a/scripts/bin/test_nells.py
+++ b/scripts/bin/test_nells.py
@@ -1,0 +1,181 @@
+from __future__ import print_function
+from orphics import maps,io,cosmology,stats
+from pixell import enmap,utils,curvedsky as cs
+import numpy as np
+import os,sys
+import mapsims
+from enlib import bench
+import healpy as hp
+
+"""
+Integration tests to compare healpix and CAR sims
+against reported noise curves.
+"""
+
+out_path = "/scratch/r/rbond/msyriac/data/depot/mapsims"
+
+def wfactor(n,mask,sht=True,pmap=None,equal_area=False):
+    """
+    Approximate correction to an n-point function for the loss of power
+    due to the application of a mask.
+
+    For an n-point function using SHTs, this is the ratio of 
+    area weighted by the nth power of the mask to the full sky area 4 pi.
+    This simplifies to mean(mask**n) for equal area pixelizations like
+    healpix. For SHTs on CAR, it is sum(mask**n * pixel_area_map) / 4pi.
+    When using FFTs, it is the area weighted by the nth power normalized
+    to the area of the map. This also simplifies to mean(mask**n)
+    for equal area pixels. For CAR, it is sum(mask**n * pixel_area_map) 
+    / sum(pixel_area_map).
+
+    If not, it does an expensive calculation of the map of pixel areas. If this has
+    been pre-calculated, it can be provided as the pmap argument.
+    
+    """
+    assert mask.ndim==1 or mask.ndim==2
+    if pmap is None: 
+        if equal_area:
+            npix = mask.size
+            pmap = 4*np.pi / npix if sht else enmap.area(mask.shape,mask.wcs) / npix
+        else:
+            pmap = enmap.pixsizemap(mask.shape,mask.wcs)
+    return np.sum((mask**n)*pmap) /np.pi / 4. if sht else np.sum((mask**n)*pmap) / np.sum(pmap)
+
+
+test_nell_standard = False
+if test_nell_standard:
+    shape,wcs = enmap.fullsky_geometry(res=2.0 * utils.arcmin)
+    noise = 10.0
+    lknee = 3000
+    alpha = -4
+    pmap = maps.psizemap(shape,wcs)
+    ivar = maps.ivar(shape,wcs,noise,ipsizemap=pmap)
+    imap = maps.modulated_noise_map(ivar,lknee=lknee,alpha=alpha,lmax=4000,lmin=50)
+    alm = cs.map2alm(imap*np.sqrt(ivar/pmap),lmax=4000)
+    cls = hp.alm2cl(alm)
+    ls = np.arange(len(cls))
+    N_ell = maps.atm_factor(ls,lknee,alpha) + 1.
+    N_ell[ls<50] = 0
+    pl = io.Plotter('Cell')
+    pl.add(ls,cls)
+    pl.add(ls,N_ell,ls='--')
+    pl.done(f'{out_path}/mapsims_nells_test.png')
+
+
+
+def get_sim(healpix,homogeneous,white,scale_to_rms=None):
+
+    if not(healpix):
+        mask = enmap.read_map("/scratch/r/rbond/msyriac/data/depot/actlens/car_mask_lmax_3000_apodized_2.0_deg.fits")[0]
+        shape,wcs = mask.shape,mask.wcs
+        nside = None
+        w2 = wfactor(2,mask)
+        map2alm = lambda x,lmax: cs.map2alm(x,lmax=lmax)
+
+    else:
+        shape = None
+        wcs = None
+        mask = hp.read_map("/scratch/r/rbond/msyriac/data/depot/solenspipe/lensing_mask_nside_2048_apodized_4.0.fits")
+        nside = 2048
+        w2 = wfactor(2,mask,equal_area=True)
+        map2alm = lambda x,lmax: hp.map2alm(x,lmax=lmax)
+
+    tube = 'LT2'
+
+    with bench.show("init"):
+        nsim = mapsims.SONoiseSimulator \
+        ( \
+            nside=nside,
+            shape=shape,
+            wcs=wcs,
+            ell_max=None,
+            return_uK_CMB=True,
+            sensitivity_mode="baseline",
+            apply_beam_correction=False,
+            apply_kludge_correction=True,
+            homogeneous=homogeneous,
+            no_power_below_ell=None,
+            rolloff_ell=50,
+            survey_efficiency=0.2,
+            full_covariance=True,
+            LA_years=5,
+            LA_noise_model="SOLatV3point1",
+            elevation=50,
+            SA_years=5,
+            SA_one_over_f_mode="pessimistic",
+            sky_fraction=None,
+            cache_hitmaps=True,
+            boolean_sky_fraction=False,
+        )
+    
+    
+    with bench.show("sim"):
+        omap = nsim.simulate(
+            tube,
+            output_units="uK_CMB",
+            seed=None,
+            nsplits=1,
+            mask_value=0,
+            atmosphere=not(white),
+            hitmap=None,
+            white_noise_rms=scale_to_rms,
+        )
+
+    # io.hplot(omap[0][0][0],f'{out_path}/mapsims_sim_homogeneous_{homogeneous}_white_{white}_scale_to_rms_{scale_to_rms}',downgrade=4,grid=True,ticks=20)
+
+    with bench.show("nells"):
+        ell, ps_T, ps_P, fsky, wnoise_power, hitmaps = nsim.get_noise_properties(tube, nsplits=1, hitmap=None, white_noise_rms=scale_to_rms,atmosphere=not(white))
+
+    with bench.show("ivar"):
+        ivar = nsim.get_inverse_variance(tube, output_units="uK_CMB", hitmap=None, white_noise_rms=scale_to_rms)        
+
+    # Calculate raw power spectrum
+    imap = omap[0][0][0]
+    imap = imap * mask
+        
+    alm = map2alm(imap,lmax=4000)
+    cls = hp.alm2cl(alm) / w2
+    ls = np.arange(len(cls))
+    pl = io.Plotter('Cell')
+    pl.add(ls,cls)
+    pl.add(ell,ps_T[0],ls='--')
+    pl.done(f'{out_path}/mapsims_nells_homogeneous_{homogeneous}_white_{white}_scale_to_rms_{scale_to_rms}_healpix_{healpix}.png')
+
+
+    # Calculate whitened map power spectrum
+    imap = np.nan_to_num(omap[0][0][0]) * np.sqrt(ivar[0]/nsim.pixarea_map) * mask
+    # io.hplot(imap,f'{out_path}/mapsims_wsim_homogeneous_{homogeneous}_white_{white}_scale_to_rms_{scale_to_rms}',downgrade=4,grid=True,ticks=20)
+    
+    alm = map2alm(imap,lmax=4000)
+    cls = hp.alm2cl(alm) / w2
+    ls = np.arange(len(cls))
+    pl = io.Plotter('Cell')
+    pl.add(ls,cls)
+    pl.add(ell,ps_T[0]/wnoise_power[0])
+    pl.done(f'{out_path}/mapsims_wnells_homogeneous_{homogeneous}_white_{white}_scale_to_rms_{scale_to_rms}_healpix_{healpix}.png')
+    
+
+get_sim(healpix=True,homogeneous=False,white=False,scale_to_rms=5.)
+get_sim(healpix=True,homogeneous=True,white=False,scale_to_rms=5.)
+get_sim(healpix=True,homogeneous=False,white=True,scale_to_rms=5.)
+get_sim(healpix=True,homogeneous=True,white=True,scale_to_rms=5.)
+
+get_sim(healpix=False,homogeneous=False,white=False,scale_to_rms=5.)
+get_sim(healpix=False,homogeneous=True,white=False,scale_to_rms=5.)
+get_sim(healpix=False,homogeneous=False,white=True,scale_to_rms=5.)
+get_sim(healpix=False,homogeneous=True,white=True,scale_to_rms=5.)
+
+
+get_sim(healpix=True,homogeneous=False,white=False,scale_to_rms=None)
+get_sim(healpix=True,homogeneous=True,white=False,scale_to_rms=None)
+get_sim(healpix=True,homogeneous=False,white=True,scale_to_rms=None)
+get_sim(healpix=True,homogeneous=True,white=True,scale_to_rms=None)
+
+get_sim(healpix=False,homogeneous=False,white=False,scale_to_rms=None)
+get_sim(healpix=False,homogeneous=True,white=False,scale_to_rms=None)
+get_sim(healpix=False,homogeneous=False,white=True,scale_to_rms=None)
+get_sim(healpix=False,homogeneous=True,white=True,scale_to_rms=None)
+
+
+
+


### PR DESCRIPTION
This includes fixes recommended in the review of #58, a bug fix for the inverse noise variance calculation and an integration test script that compares all types of noise simulations against the 
 input noise curves (currently includes some hard coded paths). Note that when atmosphere=False is requested, the noise curve returned by get_noise_properties is a flat white noise curve.