### PR TITLE
CAR and MPI fixes

### DIFF
--- a/mapsims/cmb.py
+++ b/mapsims/cmb.py
@@ -69,6 +69,8 @@ class SOPrecomputedCMB(so_pysm_models.PrecomputedAlms):
         super().__init__(
             filename,
             nside=nside,
+            target_shape=shape,
+            target_wcs=wcs,
             input_units=input_units,
             input_reference_frequency=input_reference_frequency,
             has_polarization=has_polarization,
@@ -110,6 +112,8 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
         super().__init__(
             filename,
             nside=nside,
+            target_shape=shape,
+            target_wcs=wcs,
             input_units=input_units,
             input_reference_frequency=input_reference_frequency,
             has_polarization=has_polarization,

--- a/mapsims/runner.py
+++ b/mapsims/runner.py
@@ -1,4 +1,5 @@
 import importlib
+import os
 import os.path
 from astropy.table import Table
 from astropy.utils import data
@@ -17,6 +18,7 @@ from so_pysm_models import get_so_models
 from .utils import DEFAULT_INSTRUMENT_PARAMETERS
 
 try:
+    if os.environ['DISABLE_MPI']: raise ImportError
     from mpi4py import MPI
 
     COMM_WORLD = MPI.COMM_WORLD


### PR DESCRIPTION
1. passes shape and wcs parameters to so_pysm_models
2. raises an ImportError if the DISABLE_MPI envvar is set, falling back to no MPI