### PR TITLE
Return wcs to CMB signal map if CAR

### DIFF
--- a/mapsims/cmb.py
+++ b/mapsims/cmb.py
@@ -137,6 +137,14 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
         output_units : str
             Units as defined by `pysm.convert_units`, e.g. uK_CMB or K_RJ
         """
+        
+        def _wrap_wcs(x):
+            if self.wcs is not None:
+                from pixell import enmap
+                return enmap.enmap(x,self.wcs)
+            else:
+                return x
+            
         if isinstance(ch, tuple):
             if self.nside is None:
                 raise NotImplementedError("Tube simulations for CAR not supported yet")
@@ -144,14 +152,14 @@ class SOStandalonePrecomputedCMB(so_pysm_models.PrecomputedAlms):
                 (len(ch), 3, hp.nside2npix(self.nside)), dtype=np.float64
             )
             for i, each in enumerate(ch):
-                output_map[i] = self.get_emission(
+                output_map[i] = _wrap_wcs(self.get_emission(
                     freqs=each.center_frequency, fwhm=each.beam, output_units=output_units
-                )
+                ))
             return output_map
         else:
-            return self.get_emission(
+            return _wrap_wcs(self.get_emission(
                 freqs=ch.center_frequency, fwhm=ch.beam, output_units=output_units
-            )
+            ))
 
 
 def _get_default_cmb_directory():


### PR DESCRIPTION
Currently, the WCS is destroyed when units are applied. EDIT: Not a critical fix, tutorial kernel doesnt need to be updated immediately.